### PR TITLE
Add partial immutability

### DIFF
--- a/bin/interpreter.ml
+++ b/bin/interpreter.ml
@@ -8,84 +8,110 @@ exception Unimplemented
 
 let rec eval_expr (state:PrgmSt.t) (e:expr) =
   match e with
-  | Int x -> Int x
-  | Bool x -> Bool x
-  | EString x -> EString x
-  | Systime -> Int (int_of_float (Sys.time () *. 1000.0))
+  | Int x -> (Int x, state)
+  | Bool x -> (Bool x, state)
+  | EString x -> (EString x, state)
+  | Systime -> (Int (int_of_float (Sys.time () *. 1000.0)), state)
 
   | Plus(e1, e2) ->
-    (match eval_expr state e1, eval_expr state e2 with
-    | Int i1, Int i2 -> Int(i1 + i2)
+    let i1, state2 = eval_expr state e1 in
+    let i2, state3 = eval_expr state2 e2 in
+    (match i1, i2 with
+    | Int i1, Int i2 -> (Int(i1 + i2), state3)
     | _ -> raise TypeMismatch)
   
   | Minus(e1, e2) ->
-    (match eval_expr state e1, eval_expr state e2 with
-    | Int i1, Int i2 -> Int(i1 - i2)
+    let i1, state2 = eval_expr state e1 in
+    let i2, state3 = eval_expr state2 e2 in
+    (match i1, i2 with
+    | Int i1, Int i2 -> (Int(i1 - i2), state3)
     | _ -> raise TypeMismatch)
     
   | Times(e1, e2) ->
-    (match eval_expr state e1, eval_expr state e2 with
-    | Int i1, Int i2 -> Int(i1 * i2)
+    let i1, state2 = eval_expr state e1 in
+    let i2, state3 = eval_expr state2 e2 in
+    (match i1, i2 with
+    | Int i1, Int i2 -> (Int(i1 * i2), state3)
     | _ -> raise TypeMismatch)
     
   | Div(e1, e2) ->
-    (match eval_expr state e1, eval_expr state e2 with
-    | Int i1, Int i2 -> Int(i1 / i2)
+    let i1, state2 = eval_expr state e1 in
+    let i2, state3 = eval_expr state2 e2 in
+    (match i1, i2 with
+    | Int i1, Int i2 -> (Int(i1 / i2), state3)
     | _ -> raise TypeMismatch)
 
   | Modulo(e1, e2) ->
-    (match eval_expr state e1, eval_expr state e2 with
-    | Int i1, Int i2 -> Int(i1 mod i2)
+    let i1, state2 = eval_expr state e1 in
+    let i2, state3 = eval_expr state2 e2 in
+    (match i1, i2 with
+    | Int i1, Int i2 -> (Int(i1 mod i2), state3)
     | _ -> raise TypeMismatch)
   
   | Less(e1, e2) ->
-    (match eval_expr state e1, eval_expr state e2 with
-    | Int i1, Int i2 -> Bool(i1 < i2)
+    let i1, state2 = eval_expr state e1 in
+    let i2, state3 = eval_expr state2 e2 in
+    (match i1, i2 with
+    | Int i1, Int i2 -> (Bool(i1 < i2), state3)
     | _ -> raise TypeMismatch)
   
   | LessEq(e1, e2) ->
-    (match eval_expr state e1, eval_expr state e2 with
-    | Int i1, Int i2 -> Bool(i1 <= i2)
+    let i1, state2 = eval_expr state e1 in
+    let i2, state3 = eval_expr state2 e2 in
+    (match i1, i2 with
+    | Int i1, Int i2 -> (Bool(i1 <= i2), state3)
     | _ -> raise TypeMismatch)
   
   | Greater(e1, e2) ->
-    (match eval_expr state e1, eval_expr state e2 with
-    | Int i1, Int i2 -> Bool(i1 > i2)
+    let i1, state2 = eval_expr state e1 in
+    let i2, state3 = eval_expr state2 e2 in
+    (match i1, i2 with
+    | Int i1, Int i2 -> (Bool(i1 > i2), state3)
     | _ -> raise TypeMismatch)
   
   | GreaterEq(e1, e2) ->
-    (match eval_expr state e1, eval_expr state e2 with
-    | Int i1, Int i2 -> Bool(i1 >= i2)
+    let i1, state2 = eval_expr state e1 in
+    let i2, state3 = eval_expr state2 e2 in
+    (match i1, i2 with
+    | Int i1, Int i2 -> (Bool(i1 >= i2), state3)
     | _ -> raise TypeMismatch)
 
   | Not(x) ->
-    (match eval_expr state x with
-    | Bool b -> Bool (not b)
+    let new_x, new_state = eval_expr state x in
+    (match new_x with
+    | Bool b -> (Bool (not b), new_state)
     | _ -> raise TypeMismatch)
 
   | And(e1, e2) ->
-    (match eval_expr state e1, eval_expr state e2 with
-    | Bool b1, Bool b2 -> Bool(b1 && b2)
+    let b1, state2 = eval_expr state e1 in
+    let b2, state3 = eval_expr state2 e2 in
+    (match b1, b2 with
+    | Bool b1, Bool b2 -> (Bool(b1 && b2), state3)
     | _ -> raise TypeMismatch)
 
   | Or(e1, e2) ->
-    (match eval_expr state e1, eval_expr state e2 with
-    | Bool b1, Bool b2 -> Bool(b1 || b2)
+    let b1, state2 = eval_expr state e1 in
+    let b2, state3 = eval_expr state2 e2 in
+    (match b1, b2 with
+    | Bool b1, Bool b2 -> (Bool(b1 || b2), state3)
     | _ -> raise TypeMismatch)
 
   | Equals(e1, e2) ->
-    (match eval_expr state e1, eval_expr state e2 with
-    | Int i1, Int i2 -> Bool(i1 = i2)
-    | Bool b1, Bool b2 -> Bool(b1 = b2)
+    let x1, state2 = eval_expr state e1 in
+    let x2, state3 = eval_expr state2 e2 in
+    (match x1, x2 with
+    | Int i1, Int i2 -> (Bool(i1 = i2), state3)
+    | Bool b1, Bool b2 -> (Bool(b1 = b2), state3)
     | _ -> raise TypeMismatch)
 
   | Ternary(c, e1, e2) ->
-    (match eval_expr state c with
-    | Bool true -> eval_expr state e1
-    | Bool false -> eval_expr state e2
+    let new_c, new_state = eval_expr state c in
+    (match new_c with
+    | Bool true -> eval_expr new_state e1
+    | Bool false -> eval_expr new_state e2
     | _ -> raise TypeMismatch)
 
-  | Var(i) -> PrgmSt.find_var state i
+  | Var(i) -> (PrgmSt.find_var state i, state)
   
   (* | _ -> raise Unimplemented *)
 
@@ -94,11 +120,18 @@ let rec flatten_list (accum:'b -> 'a -> 'b) (l:'a list) (i:'b) =
   | [] -> i
   | sm :: l2 -> accum i sm |> flatten_list accum l2
 
+let rec map_list_expr el s =
+  match el with
+  | [] -> []
+  | e::new_el -> let ce, new_s = eval_expr s e in
+    ce::map_list_expr new_el new_s
+
 let rec eval_statement (state:PrgmSt.t) (sm:statement) = 
   match sm with
 
   | Assign(v, e) -> 
-    PrgmSt.add_var state v (eval_expr state e)
+    let new_e, new_state = eval_expr state e in
+    PrgmSt.add_var new_state v new_e
   
   | FuncDef(i, vl, sml) ->
     PrgmSt.add_func state i (vl, sml)
@@ -106,25 +139,27 @@ let rec eval_statement (state:PrgmSt.t) (sm:statement) =
   | FuncCall(i, el) ->
     let (vl, sml) = PrgmSt.find_func state i in
     let pushed_state = PrgmSt.push_stack state in
-    let new_state = List.combine vl (List.map (eval_expr pushed_state) el) |> PrgmSt.add_vars pushed_state in
+    let new_state = List.combine vl (map_list_expr el pushed_state) |> PrgmSt.add_vars pushed_state in
     flatten_list eval_statement sml new_state |> PrgmSt.pop_stack
 
   | If(l) ->
     (match l with
     | [] -> state
     | (b, sml) :: xs ->
-      (match eval_expr state b with
-      | Bool true -> flatten_list eval_statement sml state
-      | Bool false -> eval_statement state (If xs)
+      let new_b, new_state = eval_expr state b in
+      (match new_b with
+      | Bool true -> flatten_list eval_statement sml new_state
+      | Bool false -> eval_statement new_state (If xs)
       | _ -> raise TypeMismatch))
   
   | While(e, sml) ->
-    (match eval_expr state e with
+    let new_e, new_state = eval_expr state e in
+    (match new_e with
     | Bool true -> 
-      let new_state = flatten_list eval_statement sml state in 
-      eval_statement new_state sm
+      let new_new_state = flatten_list eval_statement sml new_state in 
+      eval_statement new_new_state sm
 
-    | Bool false -> state
+    | Bool false -> new_state
     | _ -> raise TypeMismatch)
 
   | For(is, e, ls, sml) ->
@@ -132,12 +167,13 @@ let rec eval_statement (state:PrgmSt.t) (sm:statement) =
     eval_statement new_state (While(e, sml @ [ls]))
 
   | Print(e) -> 
-    Printf.printf "%s" (match eval_expr state e with
+    let new_e, new_state = eval_expr state e in
+    Printf.printf "%s" (match new_e with
      | Int x -> string_of_int x
      | Bool x -> string_of_bool x
      | EString x -> x
      | _ -> "somethin else");
-     state
+     new_state
 
   | PrintLn(e) ->
     let state = eval_statement state (Print e) in

--- a/bin/interpreter.ml
+++ b/bin/interpreter.ml
@@ -167,8 +167,9 @@ let rec eval_statement (state:PrgmSt.t) (sm:statement) =
     | _ -> raise TypeMismatch)
 
   | For(is, e, ls, sml) ->
-    let new_state = eval_statement state is in
-    eval_statement new_state (While(e, sml @ [ls]))
+    let pushed_state = PrgmSt.push_stack state in
+    let new_state = eval_statement pushed_state is in
+    eval_statement new_state (While(e, sml @ [ls])) |> PrgmSt.pop_stack
 
   | Print(e) -> 
     let new_e, new_state = eval_expr state e in

--- a/bin/state.ml
+++ b/bin/state.ml
@@ -7,117 +7,82 @@ module IdentMap = Map.Make(Ident);;
 module StLvl =
   struct
     type t = 
-    | StLvl of (Ident.t, (Ident.t list * statement list)) Hashtbl.t * (Ident.t, expr) Hashtbl.t
+    | StLvl of (Ident.t list * statement list) IdentMap.t * expr IdentMap.t
     let add_var s i v =
       match s with
-      | StLvl(_, vm) -> Hashtbl.replace vm i v
+      | StLvl(fm, vm) -> StLvl (fm, IdentMap.add i v vm)
     let rec add_vars s (ivl:(Ident.t * expr) list) =
       match ivl with
-      | [] -> ()
-      | (i, v)::ivl2 -> add_var s i v; add_vars s ivl2
+      | [] -> s
+      | (i, v)::ivl2 -> add_vars (add_var s i v) ivl2
     let add_func s i f =
       match s with
-      | StLvl(fm, _) -> Hashtbl.replace fm i f
+      | StLvl(fm, vm) -> StLvl (IdentMap.add i f fm, vm)
     let find_var_opt s i =
       match s with
-      | StLvl(_, vm) -> Hashtbl.find_opt vm i
+      | StLvl(_, vm) -> IdentMap.find_opt i vm
     let find_func_opt s i =
       match s with
-      | StLvl(fm, _) -> Hashtbl.find_opt fm i
+      | StLvl(fm, _) -> IdentMap.find_opt i fm
     let empty =
-      StLvl (Hashtbl.create 100, Hashtbl.create 100)
+      StLvl (IdentMap.empty, IdentMap.empty)
   end
-(* 
-let program_state : StLvl.t list ref = (ref [StLvl.empty])
-
-let push_stack = program_state := StLvl.empty :: !program_state
-
-let pop_stack = 
-  (match !program_state with
-  | [] -> raise Invalid_state
-  | _ :: new_sl -> program_state := new_sl)
-
-let rec add_var i v =
-  (match !program_state with
-  | [] -> raise Invalid_state
-  | s :: _ -> StLvl.add_var s i v)
-
-let add_vars ivl = 
-  (match !program_state with
-  | [] -> raise Invalid_state
-  | s :: _ -> StLvl.add_vars s ivl)
-
-let add_func i f =
-  (match !program_state with
-  | [] -> raise Invalid_state
-  | s :: _ -> StLvl.add_func s i f)
-
-let rec find_var p i = 
-  (match !p with
-  | [] -> raise Not_found
-  | s :: new_sl ->
-    (match StLvl.find_var_opt s i with
-    | Some(v) -> v
-    | None -> find_var (ref new_sl) i))
-
-let rec find_func p i =
-  (match !p with
-  | [] -> raise Not_found
-  | s::new_sl ->
-    (match StLvl.find_func_opt s i with
-    | Some(f) -> f
-    | None -> find_func (ref new_sl) i)) *)
 
 module PrgmSt =
   struct
-    type t = StLvl.t list ref
-    let push_stack sl = (* function *)
-    (* | PrgmSt(sl) -> *)
-      sl := StLvl.empty :: !sl;;
-    let pop_stack sl = (* function *)
-    (* | PrgmSt(sl) ->  *)
-      (match !sl with
+    type t =
+    | PrgmSt of StLvl.t list
+    let push_stack = function
+    | PrgmSt(sl) ->
+      let new_sl = StLvl.empty::sl in
+      PrgmSt new_sl
+    let pop_stack = function
+    | PrgmSt(sl) -> 
+      (match sl with
       | [] -> raise Invalid_state
-      | _ :: new_sl -> sl := new_sl)
-    let add_var sl i v =
-      (* match p with
-      | PrgmSt(sl) -> *)
-        (match !sl with
+      | _::new_sl -> PrgmSt new_sl)
+    let add_var p i v =
+      match p with
+      | PrgmSt(sl) ->
+        (match sl with
         | [] -> raise Invalid_state
-        | s :: _ ->
-          StLvl.add_var s i v)
-    let add_vars sl (ivl:(Ident.t * expr) list) =
-      (* match p with
-      | PrgmSt(sl) -> *)
-        (match !sl with
+        | s::new_sl ->
+          let new_s = StLvl.add_var s i v in
+          PrgmSt (new_s::new_sl))
+    let add_vars p (ivl:(Ident.t * expr) list) =
+      match p with
+      | PrgmSt(sl) ->
+        (match sl with
         | [] -> raise Invalid_state
-        | s :: _ ->
-          StLvl.add_vars s ivl)
-    let add_func sl i f =
-      (* match p with
-      | PrgmSt(sl) -> *)
-        (match !sl with
+        | s::new_sl ->
+          let new_s = StLvl.add_vars s ivl in
+          PrgmSt (new_s::new_sl))
+    let add_func p i f =
+      match p with
+      | PrgmSt(sl) ->
+        (match sl with
         | [] -> raise Invalid_state
-        | s :: _ ->
-          StLvl.add_func s i f)
-    let rec find_var sl i =
-      (* match p with
-      | PrgmSt(sl) -> *)
-        (match !sl with
+        | s::new_sl ->
+          let new_s = StLvl.add_func s i f in
+          PrgmSt (new_s::new_sl))
+    let rec find_var p i =
+      match p with
+      | PrgmSt(sl) ->
+        (match sl with
         | [] -> raise Not_found
-        | s :: new_sl ->
+        | s::new_sl ->
           (match StLvl.find_var_opt s i with
           | Some(v) -> v
-          | None -> find_var (ref new_sl) i))
-    let rec find_func sl i =
-      (* match p with
-      | PrgmSt(sl) -> *)
-        (match !sl with
+          | None -> find_var (PrgmSt new_sl) i))
+    let rec find_func p i =
+      match p with
+      | PrgmSt(sl) ->
+        (match sl with
         | [] -> raise Not_found
-        | s :: new_sl ->
+        | s::new_sl ->
           (match StLvl.find_func_opt s i with
           | Some(f) -> f
-          | None -> find_func (ref new_sl) i))
+          | None -> find_func (PrgmSt new_sl) i))
     let empty =
-      ref [StLvl.empty]
+      PrgmSt [StLvl.empty]
   end

--- a/bin/state.ml
+++ b/bin/state.ml
@@ -7,25 +7,25 @@ module IdentMap = Map.Make(Ident);;
 module StLvl =
   struct
     type t = 
-    | StLvl of (Ident.t list * statement list) IdentMap.t * expr IdentMap.t
+    | StLvl of (Ident.t, (Ident.t list * statement list)) Hashtbl.t * (Ident.t, expr) Hashtbl.t
     let add_var s i v =
       match s with
-      | StLvl(fm, vm) -> StLvl (fm, IdentMap.add i v vm)
+      | StLvl(fm, vm) -> Hashtbl.replace vm i v; StLvl (fm, vm)
     let rec add_vars s (ivl:(Ident.t * expr) list) =
       match ivl with
       | [] -> s
       | (i, v)::ivl2 -> add_vars (add_var s i v) ivl2
     let add_func s i f =
       match s with
-      | StLvl(fm, vm) -> StLvl (IdentMap.add i f fm, vm)
+      | StLvl(fm, vm) -> Hashtbl.replace fm i f; StLvl (fm, vm)
     let find_var_opt s i =
       match s with
-      | StLvl(_, vm) -> IdentMap.find_opt i vm
+      | StLvl(_, vm) -> Hashtbl.find_opt vm i
     let find_func_opt s i =
       match s with
-      | StLvl(fm, _) -> IdentMap.find_opt i fm
+      | StLvl(fm, _) -> Hashtbl.find_opt fm i
     let empty =
-      StLvl (IdentMap.empty, IdentMap.empty)
+      StLvl (Hashtbl.create 64, Hashtbl.create 32)
   end
 
 module PrgmSt =

--- a/bin/state.ml
+++ b/bin/state.ml
@@ -24,7 +24,7 @@ module StLvl =
     let find_func_opt s i =
       match s with
       | StLvl(fm, _) -> Hashtbl.find_opt fm i
-    let empty =
+    let empty () =
       StLvl (Hashtbl.create 64, Hashtbl.create 32)
   end
 
@@ -34,8 +34,7 @@ module PrgmSt =
     | PrgmSt of StLvl.t list
     let push_stack = function
     | PrgmSt(sl) ->
-      let new_sl = StLvl.empty::sl in
-      PrgmSt new_sl
+      PrgmSt (StLvl.empty ()::sl)
     let pop_stack = function
     | PrgmSt(sl) -> 
       (match sl with
@@ -84,5 +83,5 @@ module PrgmSt =
           | Some(f) -> f
           | None -> find_func (PrgmSt new_sl) i))
     let empty =
-      PrgmSt [StLvl.empty]
+      PrgmSt [StLvl.empty ()]
   end

--- a/input.doot
+++ b/input.doot
@@ -1,74 +1,14 @@
-println "hello lmao";
-a = 8;
-println a;
-a = 5;
-println a;
+foo = "before_func";
 
-bruhbruh = "yuer";
-println bruhbruh;
-
-sure = true;
-maybe = true;
-
-if (sure) {
-    println "yeah";
-}
-
-if (!sure) {
-    println "yep";
-} else if (maybe) 
-    println "mayhaps";
-
-// balls
-if (!sure) 
-    println "yeh";
-else if (!maybe) {
-    println "maybe";
-} else
-    println "nah";
-
-
-println 10;
-
-i = 0;
-
-while (!(i == 5)) {
-    i = i + 1;
-    _a15 = 3;
-    while (!(_a15 == 0)) {
-        print i;
-        print " ";
-        println _a15;
-        _a15 = _a15 - 1;
-    }
-}
-
-for (i = 0; i <= 7; i = i + 1) {
-    print "printing: ";
-    println i;
-}
-
-var1 = "hi";
-
-type bruh(var1, foo) {
-    println "lmao";
-    println var1;
+fn foo_func(foo) {
     println foo;
 }
 
-foo = 9 + 10;
+print "Printing foo: ";
+println foo;
 
-bruh("what's up dawg", foo);
+println "Calling foo_func:";
+foo_func("inside function");
 
-print "printing var1: ";
-println var1;
-
-// one lines
-
-/*
-    multiple lines
-*/
-
-println 32 % 3;
-
-/*cobment*/println "all done";
+print "Printing foo: ";
+println foo;


### PR DESCRIPTION
StLvl and PrgmSt will become immutable again, with new objects being copied instead of passed. However, instead of using a map, we will use a mutable hashtable for performance reasons.

- [x] Revert state.ml
- [x] Fix interpreter.ml
- [x] Make eval_expr return state
- [x] Replace IdentMap with a HashTbl